### PR TITLE
Fix format for horizontal icon list

### DIFF
--- a/components/list.css
+++ b/components/list.css
@@ -306,6 +306,7 @@ ol.ui.list ol li,
 .ui.horizontal.list > .item > .icon + .content {
   float: none;
   display: inline-block;
+  width: auto;
 }
 
 
@@ -950,4 +951,3 @@ ol.ui.horizontal.list li:before,
 /*******************************
     User Variable Overrides
 *******************************/
-


### PR DESCRIPTION
Format currently breaks when List uses prop horizontal and contains List.Icon and List.Content